### PR TITLE
Make digraphs behave like letters.

### DIFF
--- a/letters.py
+++ b/letters.py
@@ -10,7 +10,9 @@ def _get_letters():
   if _get_letters_cache is None:
     _get_letters_cache = json.load(open('letters.json'))
     VOWELLS = set(x for x in 'aeiouy')
-    CONSONANTES = set(ascii_lowercase).difference(VOWELLS)
+    CONSONANTES = set(ascii_lowercase).difference(VOWELLS).union(
+        set(['kp', 'gb'])
+    )
     _get_letters_cache += list(
       [letter, [letter], True] for letter in VOWELLS
     )

--- a/test.py
+++ b/test.py
@@ -53,6 +53,10 @@ class TestWordParsing(unittest.TestCase):
       (u'k^{w} ɔ', [u'k^{w}', u'ɔ']),
       (u'k^{w}(\~ɔ)', [u'k^{w}', u'\~ɔ']),
       (u'k^{w}ɔ:', [u'k^{w}', u'ɔ:']),
+      (u'kpa', [u'kp', u'a']),
+      (u'kba', [u'k', u'b', u'a']),
+      (u'gba', [u'gb', u'a']),
+      (u'gpa', [u'g', u'p', u'a']),
     ]:
       self.assertEqual(make_letters(input_text),
                        list(make_letter(x) for x in expected))
@@ -253,6 +257,8 @@ class TestLetters(unittest.TestCase):
     self.assertFalse(is_vowell('l'))
     self.assertFalse(is_vowell('k'))
     self.assertFalse(is_vowell('ʤ'))
+    self.assertFalse(is_vowell('kp'))
+    self.assertFalse(is_vowell('gb'))
 
   def test_is_not_letter(self):
     """

--- a/word_parsing.py
+++ b/word_parsing.py
@@ -301,6 +301,7 @@ _LABIALIZED = '^{w}'
 _NASAL_SUFFIX_1 = '^~'
 _NASAL_SUFFIX_2 = '^{~}'
 _NASAL_SUFFIX_3 = '~'
+_DIGRAPHS = ['kp', 'gb']
 
 def make_letter(text):
   is_labialized = False
@@ -339,6 +340,8 @@ def make_letters(text):
     split = 1
     if processed_text.startswith(_NASAL):
       split = len(_NASAL)+1
+    elif any(processed_text.startswith(x) for x in _DIGRAPHS):
+      split = 2
 
     letter = processed_text[:split]
     rest = processed_text[split:]


### PR DESCRIPTION
In Guebie, `kp` and `gb` are always digraphs. Prior to this PR, they were parsed as two separate letters by this script. After this PR, they are correctly parsed as a single letter.
